### PR TITLE
make changes in alreadyExistByCategoryAndKey() function to fix a bug in updateOption function

### DIFF
--- a/src/modules/option/option.service.js
+++ b/src/modules/option/option.service.js
@@ -44,7 +44,7 @@ class OptionService {
             optionDto.key = slugify(optionDto.key, {trim: true, replacement: "_", lower: true});
             let categoryId = existOption.category;
             if(optionDto.category) categoryId = optionDto.category;
-            await this.alreadyExistByCategoryAndKey(optionDto.key, categoryId)
+            await this.alreadyExistByCategoryAndKey(optionDto.key, categoryId, id)
         }
         if(optionDto?.enum && typeof optionDto.enum === "string") {
             optionDto.enum = optionDto.enum.split(",")
@@ -104,8 +104,8 @@ class OptionService {
         if(!option) throw new createHttpError.NotFound(OptionMessage.NotFound);
         return option;
     }
-    async alreadyExistByCategoryAndKey(key, category) {
-        const isExist = await this.#model.findOne({category, key});
+    async alreadyExistByCategoryAndKey(key, category, exceptionId = null) {
+        const isExist = await this.#model.findOne({category, key , _id : {$ne : exceptionId}});
         if(isExist) throw new createHttpError.Conflict(OptionMessage.AlreadyExist);
         return null;
     }


### PR DESCRIPTION
Now in the optionService.js, **alreadyExistByCategoryAndKey()** function has an additional parameter called **'exceptionId'** that by default is null. It's used once we want to update an option and don't want to consider it a duplicate option.

in (line: 108) `const isExist = await this.#model.findOne({category, key , _id : {$ne : exceptionId}}); `we say find any option with the corresponding **key** and **category** except the option that we are going to update it.